### PR TITLE
fix: Layout shift on fixed elements when dialogs are open

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-day-picker": "^9.8.0",
     "react-dom": "19.0.0",
     "react-hook-form": "7.45.4",
+    "react-remove-scroll-bar": "^2.3.8",
     "react-textarea-autosize": "^8.5.9",
     "sharp": "0.32.6",
     "sonner": "^2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       react-hook-form:
         specifier: 7.45.4
         version: 7.45.4(react@19.0.0)
+      react-remove-scroll-bar:
+        specifier: ^2.3.8
+        version: 2.3.8(@types/react@19.0.12)(react@19.0.0)
       react-textarea-autosize:
         specifier: ^8.5.9
         version: 8.5.9(@types/react@19.0.12)(react@19.0.0)

--- a/src/features/shared/components/BottomMenu.tsx
+++ b/src/features/shared/components/BottomMenu.tsx
@@ -4,9 +4,16 @@ import { DocPadPopoverButton } from '@/features/docPad/components/DocPadPopoverB
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/utilities/ui'
 
+import { noScrollbarsClassName } from 'react-remove-scroll-bar'
+
 export function BottomMenu() {
   return (
-    <div className="fixed bottom-0 z-10 flex h-12 w-full justify-between sm:h-16">
+    <div
+      className={cn(
+        noScrollbarsClassName,
+        'fixed bottom-0 z-10 flex h-12 w-full justify-between sm:h-16',
+      )}
+    >
       <div className="w-16 sm:w-28">
         <Popover>
           <PopoverTrigger asChild>

--- a/src/features/shared/components/RightMenu.tsx
+++ b/src/features/shared/components/RightMenu.tsx
@@ -4,6 +4,8 @@ import { cn } from '@/utilities/ui'
 import { DictionaryButton } from '@/features/dictionary/components/DictionaryButton'
 import { MoreOptionsMenu } from '@/features/moreOptions/components/MoreOptionsMenu'
 
+import { zeroRightClassName } from 'react-remove-scroll-bar'
+
 export function RightMenu() {
   return (
     <div
@@ -21,7 +23,7 @@ export function RightMenu() {
 
 export function RightMenuContainer() {
   return (
-    <div className="fixed right-0 top-[35%] z-50 hidden sm:block">
+    <div className={cn(zeroRightClassName, 'fixed right-0 top-[35%] z-50 hidden sm:block')}>
       <RightMenu />
     </div>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved BottomMenu and RightMenu components to hide scrollbars for a cleaner appearance.

* **Chores**
  * Added the "react-remove-scroll-bar" package as a new dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->