### PR TITLE
fix: Topic showing in table of contents without content

### DIFF
--- a/src/features/scope/components/ScopeLeftMenu.tsx
+++ b/src/features/scope/components/ScopeLeftMenu.tsx
@@ -33,7 +33,9 @@ export function ScopeLeftMenu({ sectionData }: LeftMenuProps) {
           if (!data) return null
           const { topic, articlesByCategory } = data
 
-          if (articlesByCategory.length === 0) return null
+          const hasArticles = articlesByCategory.some(({ articles }) => articles.length > 0)
+
+          if (articlesByCategory.length === 0 || !hasArticles) return null
 
           return (
             <AccordionItem value={`item-${index + 1}`} key={topic.id}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display logic for the left menu to prevent showing empty accordion items when there are no articles available in any category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->