### PR TITLE
Highlight exp button if not off

### DIFF
--- a/src/features/articles/textSize/components/TextSizeButton.tsx
+++ b/src/features/articles/textSize/components/TextSizeButton.tsx
@@ -13,7 +13,14 @@ export function TextSizeButton() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <ArticleMenuButton aria-label="Adjust text size">EXP</ArticleMenuButton>
+        <ArticleMenuButton
+          className={cn({
+            'text-yellow-200': textSize !== 'off',
+          })}
+          aria-label="Adjust text size"
+        >
+          EXP
+        </ArticleMenuButton>
       </PopoverTrigger>
 
       <PopoverContent className="flex w-32 flex-col items-center justify-center border-black bg-menu p-0">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The text size button now highlights in yellow when a text size option is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->