### PR TITLE
Turn article ad section into postings section

### DIFF
--- a/src/blocks/RenderArticleBlocks.tsx
+++ b/src/blocks/RenderArticleBlocks.tsx
@@ -1,23 +1,23 @@
 import React, { Fragment } from 'react'
 
 import {
-  AdSection as AdSectionBlockType,
+  PostingsSection as PostingsSectionBlockType,
   ContentSection as ContentSectionType,
   ResourceSection as ResourceSectionType,
 } from '@/payload-types'
 
-import { AdSectionBlock } from './article-blocks/AdSection/Component'
+import { PostingsSectionBlock } from './article-blocks/PostingsSection/Component'
 import { ContentSection } from './article-blocks/ContentSection/Component'
 import { ResourceSection } from './article-blocks/ResourceSection/Component'
 
 const blockComponents = {
-  adSection: AdSectionBlock,
+  postingsSection: PostingsSectionBlock,
   contentSection: ContentSection,
   resourceSection: ResourceSection,
 }
 
 export const RenderArticleBlocks: React.FC<{
-  blocks: (AdSectionBlockType | ContentSectionType | ResourceSectionType)[] | null
+  blocks: (PostingsSectionBlockType | ContentSectionType | ResourceSectionType)[] | null
 }> = ({ blocks }) => {
   const validBlocks = Array.isArray(blocks) ? blocks : []
   if (validBlocks.length > 0) {

--- a/src/blocks/article-blocks/PostingsSection/Component.tsx
+++ b/src/blocks/article-blocks/PostingsSection/Component.tsx
@@ -50,7 +50,7 @@ export const PostingsSectionBlock: React.FC<PostingsSectionProps> = (props) => {
               )
             })
           ) : (
-            <div className="py-4 text-center">No advertisements available</div>
+            <div className="py-4 text-center">No postings available</div>
           )}
         </div>
       </div>

--- a/src/blocks/article-blocks/PostingsSection/Component.tsx
+++ b/src/blocks/article-blocks/PostingsSection/Component.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { CMSLink } from '@/components/Link'
-import { AdSection as AdSectionProps } from '@/payload-types'
+import { PostingsSection as PostingsSectionProps } from '@/payload-types'
 import React from 'react'
 import clsx from 'clsx'
 import { ImagePlaceholder } from '@/features/shared/components/ImagePlaceholder'
@@ -9,10 +9,10 @@ import { RenderMedia } from '@/features/shared/components/RenderMedia'
 import TitleBar from '../TitleBar'
 import { useReadMode } from '@/providers/ReadModeProvider'
 
-export const AdSectionBlock: React.FC<AdSectionProps> = (props) => {
+export const PostingsSectionBlock: React.FC<PostingsSectionProps> = (props) => {
   const { readMode } = useReadMode()
 
-  const { title, ads } = props
+  const { title, postings } = props
 
   if (readMode) return null
 
@@ -22,8 +22,8 @@ export const AdSectionBlock: React.FC<AdSectionProps> = (props) => {
 
       <div className="border-content w-full overflow-x-auto py-4 md:py-8">
         <div className="mx-auto flex w-fit gap-6 px-4 xl:px-16">
-          {ads && ads.length > 0 ? (
-            ads.map(({ id, link, media }, index) => {
+          {postings && postings.length > 0 ? (
+            postings.map(({ id, link, media }, index) => {
               const hasValidLink =
                 link && (link.type === 'reference' ? link.reference : link.type === 'custom')
 

--- a/src/blocks/article-blocks/PostingsSection/config.ts
+++ b/src/blocks/article-blocks/PostingsSection/config.ts
@@ -2,7 +2,7 @@ import { Block, Field } from 'payload'
 
 import { link } from '@/fields/link'
 
-const AdFields: Field[] = [
+const PostingsFields: Field[] = [
   {
     name: 'media',
     type: 'upload',
@@ -23,9 +23,9 @@ const AdFields: Field[] = [
   }),
 ]
 
-export const AdSection: Block = {
-  slug: 'adSection',
-  interfaceName: 'AdSection',
+export const PostingsSection: Block = {
+  slug: 'postingsSection',
+  interfaceName: 'PostingsSection',
   fields: [
     {
       name: 'title',
@@ -34,12 +34,12 @@ export const AdSection: Block = {
       required: true,
     },
     {
-      name: 'ads',
+      name: 'postings',
       type: 'array',
       admin: {
         initCollapsed: true,
       },
-      fields: AdFields,
+      fields: PostingsFields,
       maxRows: 3,
     },
   ],

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -14,7 +14,7 @@ import { CollectionConfig } from 'payload'
 
 import { revalidateArticle, revalidateDelete } from './hooks/revalidateArticle'
 import { populateAuthors } from './hooks/populateAuthors'
-import { AdSection } from '@/blocks/article-blocks/AdSection/config'
+import { PostingsSection } from '@/blocks/article-blocks/PostingsSection/config'
 import { ContentSection } from '@/blocks/article-blocks/ContentSection/config'
 import { ResourceSection } from '@/blocks/article-blocks/ResourceSection/config'
 import { link } from '@/fields/link'
@@ -81,7 +81,7 @@ export const Articles: CollectionConfig<'articles'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [AdSection, ContentSection, ResourceSection],
+              blocks: [PostingsSection, ContentSection, ResourceSection],
               admin: {
                 initCollapsed: true,
               },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -245,7 +245,7 @@ export interface Article {
   id: string;
   title: string;
   heroImage?: (string | null) | Media;
-  layout?: (AdSection | ContentSection | ResourceSection)[] | null;
+  layout?: (PostingsSection | ContentSection | ResourceSection)[] | null;
   relatedArticles?: (string | Article)[] | null;
   categories?: (string | Category)[] | null;
   otherVerifiedSources?:
@@ -407,11 +407,11 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "AdSection".
+ * via the `definition` "PostingsSection".
  */
-export interface AdSection {
+export interface PostingsSection {
   title: string;
-  ads?:
+  postings?:
     | {
         media?: (string | null) | Media;
         enableLink?: boolean | null;
@@ -434,7 +434,7 @@ export interface AdSection {
     | null;
   id?: string | null;
   blockName?: string | null;
-  blockType: 'adSection';
+  blockType: 'postingsSection';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2013,7 +2013,7 @@ export interface ArticlesSelect<T extends boolean = true> {
   layout?:
     | T
     | {
-        adSection?: T | AdSectionSelect<T>;
+        postingsSection?: T | PostingsSectionSelect<T>;
         contentSection?: T | ContentSectionSelect<T>;
         resourceSection?: T | ResourceSectionSelect<T>;
       };
@@ -2058,11 +2058,11 @@ export interface ArticlesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "AdSection_select".
+ * via the `definition` "PostingsSection_select".
  */
-export interface AdSectionSelect<T extends boolean = true> {
+export interface PostingsSectionSelect<T extends boolean = true> {
   title?: T;
-  ads?:
+  postings?:
     | T
     | {
         media?: T;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed “Ad Section” to “Postings Section” across article blocks, collection layouts, and runtime rendering.
  - Field label changed from “Ads” to “Postings” and UI fallback text updated to “No postings available.”
  - Block identifier updated to postingsSection for consistency.
  - No change to rendering behavior or layout order.

- Documentation
  - Updated public API types, docs, and references to use “Postings Section” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->