### PR TITLE
Brian/image pass 02

### DIFF
--- a/src/app/(frontend)/signin/page.tsx
+++ b/src/app/(frontend)/signin/page.tsx
@@ -16,6 +16,10 @@ import { SignedInButton } from '@/features/signin/components/SignedInButton'
 export const dynamic = 'force-static'
 export const revalidate = 600
 
+const adImageQuality = 'auto:best'
+const adImageSize =
+  '(max-width: 640px) 100vw, (max-width: 768px) 90vw, (max-width: 1920px) 75vw, 75vw'
+
 const SigninPage = async () => {
   const signinData: signinGlobalType = await getCachedGlobal('signin', 1)()
 
@@ -39,10 +43,18 @@ const SigninPage = async () => {
       >
         {hasValidLink ? (
           <CMSLink {...pageAd?.url}>
-            {pageAd?.image ? <RenderMedia media={pageAd.image as Media} /> : <ImagePlaceholder />}
+            {pageAd?.image ? (
+              <RenderMedia
+                media={pageAd.image as Media}
+                quality={adImageQuality}
+                size={adImageSize}
+              />
+            ) : (
+              <ImagePlaceholder />
+            )}
           </CMSLink>
         ) : pageAd?.image ? (
-          <RenderMedia media={pageAd.image} />
+          <RenderMedia media={pageAd.image as Media} quality={adImageQuality} size={adImageSize} />
         ) : (
           <ImagePlaceholder />
         )}

--- a/src/app/(frontend)/signin/page.tsx
+++ b/src/app/(frontend)/signin/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import React from 'react'
 import PageClient from './page.client'
 import { getCachedGlobal } from '@/utilities/getGlobals'
-import type { Media, Signin as signinGlobalType } from '@/payload-types'
+import type { Signin as signinGlobalType } from '@/payload-types'
 import { isValidLink } from '@/utilities/isValidLink'
 import { CMSLink } from '@/components/Link'
 import { RenderMedia } from '@/features/shared/components/RenderMedia'
@@ -44,17 +44,13 @@ const SigninPage = async () => {
         {hasValidLink ? (
           <CMSLink {...pageAd?.url}>
             {pageAd?.image ? (
-              <RenderMedia
-                media={pageAd.image as Media}
-                quality={adImageQuality}
-                size={adImageSize}
-              />
+              <RenderMedia media={pageAd.image} quality={adImageQuality} size={adImageSize} />
             ) : (
               <ImagePlaceholder />
             )}
           </CMSLink>
         ) : pageAd?.image ? (
-          <RenderMedia media={pageAd.image as Media} quality={adImageQuality} size={adImageSize} />
+          <RenderMedia media={pageAd.image} quality={adImageQuality} size={adImageSize} />
         ) : (
           <ImagePlaceholder />
         )}

--- a/src/blocks/MediaBlock/config.ts
+++ b/src/blocks/MediaBlock/config.ts
@@ -7,7 +7,7 @@ export const MediaBlock: Block = {
     {
       name: 'media',
       type: 'upload',
-      relationTo: 'media',
+      relationTo: 'article-media',
       required: true,
     },
   ],

--- a/src/blocks/article-blocks/ContentSection/config.ts
+++ b/src/blocks/article-blocks/ContentSection/config.ts
@@ -44,14 +44,14 @@ export const ContentSection: Block = {
     {
       name: 'image1',
       type: 'upload',
-      relationTo: 'media',
+      relationTo: 'article-media',
       label: 'Image 1',
       hasMany: false,
     },
     {
       name: 'image2',
       type: 'upload',
-      relationTo: 'media',
+      relationTo: 'article-media',
       label: 'Image 2',
       admin: {
         condition: (_, siblingData) => siblingData.alignment === 'left & right',

--- a/src/blocks/article-blocks/PostingsSection/config.ts
+++ b/src/blocks/article-blocks/PostingsSection/config.ts
@@ -6,7 +6,7 @@ const PostingsFields: Field[] = [
   {
     name: 'media',
     type: 'upload',
-    relationTo: 'media',
+    relationTo: 'article-media',
   },
   {
     name: 'enableLink',

--- a/src/cloudinaryAdapter/handleUpload.ts
+++ b/src/cloudinaryAdapter/handleUpload.ts
@@ -15,6 +15,7 @@ interface Args {
   prefix?: string
   versioning?: CloudinaryVersioningOptions
   publicID?: PublicIDOptions
+  useTimestamp?: boolean
 }
 
 const getUploadOptions = (
@@ -155,15 +156,19 @@ const getPDFPageCount = async (
 }
 
 export const getHandleUpload =
-  ({ cloudinary, folder, prefix = '', versioning, publicID }: Args): HandleUpload =>
+  ({ cloudinary, folder, prefix = '', versioning, publicID, useTimestamp }: Args): HandleUpload =>
   async ({ data, file }) => {
     // Construct the folder path with proper handling of prefix
     const folderPath = data.prefix
       ? path.posix.join(folder, data.prefix)
       : path.posix.join(folder, prefix)
 
-    // Generate the public ID based on options
-    const publicIdValue = generatePublicID(file.filename, folderPath, publicID)
+    const existingPublicId = data.cloudinary?.public_id
+
+    // Generate the Public ID based on options if no existing Public ID
+    const publicIdValue = existingPublicId
+      ? existingPublicId
+      : generatePublicID(file.filename, folderPath, publicID, useTimestamp)
 
     // Basic upload options
     const uploadOptions: UploadApiOptions = {
@@ -172,6 +177,7 @@ export const getHandleUpload =
       use_filename: publicID?.useFilename !== false,
       unique_filename: publicID?.uniqueFilename !== false,
       asset_folder: folderPath,
+      overwrite: true,
     }
 
     return new Promise((resolve, reject) => {

--- a/src/cloudinaryAdapter/handleUpload.ts
+++ b/src/cloudinaryAdapter/handleUpload.ts
@@ -170,6 +170,8 @@ export const getHandleUpload =
       ? existingPublicId
       : generatePublicID(file.filename, folderPath, publicID, useTimestamp)
 
+    const shouldOverwrite = Boolean(existingPublicId)
+
     // Basic upload options
     const uploadOptions: UploadApiOptions = {
       ...getUploadOptions(file.filename, versioning),
@@ -177,7 +179,7 @@ export const getHandleUpload =
       use_filename: publicID?.useFilename !== false,
       unique_filename: publicID?.uniqueFilename !== false,
       asset_folder: folderPath,
-      overwrite: true,
+      overwrite: shouldOverwrite,
     }
 
     return new Promise((resolve, reject) => {

--- a/src/cloudinaryAdapter/index.ts
+++ b/src/cloudinaryAdapter/index.ts
@@ -186,6 +186,7 @@ function cloudinaryStorageInternal({
         prefix: collection.slug,
         versioning,
         publicID,
+        useTimestamp: true,
       }),
       staticHandler: getHandler({ cloudinary, collection, folder }),
     }

--- a/src/collections/AdMedia.ts
+++ b/src/collections/AdMedia.ts
@@ -44,13 +44,13 @@ export const AdMedia: CollectionConfig = {
   ],
   upload: {
     staticDir: path.resolve(dirname, '../../public/ad-media'),
-    adminThumbnail: 'thumbnail',
+    // adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
+    // imageSizes: [
+    //   {
+    //     name: 'thumbnail',
+    //     width: 300,
+    //   },
+    // ],
   },
 }

--- a/src/collections/AdMedia.ts
+++ b/src/collections/AdMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const AdMedia: CollectionConfig = {
   slug: 'ad-media',
@@ -43,14 +38,6 @@ export const AdMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/ad-media'),
-    // adminThumbnail: 'thumbnail',
     focalPoint: true,
-    // imageSizes: [
-    //   {
-    //     name: 'thumbnail',
-    //     width: 300,
-    //   },
-    // ],
   },
 }

--- a/src/collections/ArtMedia.ts
+++ b/src/collections/ArtMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const ArtMedia: CollectionConfig = {
   slug: 'art-media',
@@ -43,14 +38,6 @@ export const ArtMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/art-media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
   },
 }

--- a/src/collections/ArticleMedia.ts
+++ b/src/collections/ArticleMedia.ts
@@ -11,6 +11,10 @@ import { authenticated } from '../access/authenticated'
 
 export const ArticleMedia: CollectionConfig = {
   slug: 'article-media',
+  labels: {
+    singular: 'Article Media',
+    plural: 'Article Media',
+  },
   access: {
     create: authenticated,
     delete: authenticated,

--- a/src/collections/ArticleMedia.ts
+++ b/src/collections/ArticleMedia.ts
@@ -1,0 +1,39 @@
+import type { CollectionConfig } from 'payload'
+
+import {
+  FixedToolbarFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from '@payloadcms/richtext-lexical'
+
+import { anyone } from '../access/anyone'
+import { authenticated } from '../access/authenticated'
+
+export const ArticleMedia: CollectionConfig = {
+  slug: 'article-media',
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: anyone,
+    update: authenticated,
+  },
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'caption',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ rootFeatures }) => {
+          return [...rootFeatures, FixedToolbarFeature(), InlineToolbarFeature()]
+        },
+      }),
+    },
+  ],
+  upload: {
+    focalPoint: true,
+  },
+}

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -71,7 +71,7 @@ export const Articles: CollectionConfig<'articles'> = {
             {
               name: 'heroImage',
               type: 'upload',
-              relationTo: 'media',
+              relationTo: 'article-media',
             },
           ],
           label: 'Hero',
@@ -164,7 +164,7 @@ export const Articles: CollectionConfig<'articles'> = {
               hasGenerateFn: true,
             }),
             MetaImageField({
-              relationTo: 'media',
+              relationTo: 'article-media',
             }),
 
             MetaDescriptionField({}),

--- a/src/collections/HealthAndWellnessMedia.ts
+++ b/src/collections/HealthAndWellnessMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const HealthAndWellnessMedia: CollectionConfig = {
   slug: 'health-and-wellness-media',
@@ -43,14 +38,6 @@ export const HealthAndWellnessMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/health-and-wellness-media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
   },
 }

--- a/src/collections/HomeMedia.ts
+++ b/src/collections/HomeMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const HomeMedia: CollectionConfig = {
   slug: 'home-media',
@@ -43,14 +38,6 @@ export const HomeMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/home-media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
   },
 }

--- a/src/collections/LiteratureMedia.ts
+++ b/src/collections/LiteratureMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const LiteratureMedia: CollectionConfig = {
   slug: 'literature-media',
@@ -43,14 +38,6 @@ export const LiteratureMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/literature-media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
   },
 }

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -5,14 +5,9 @@ import {
   InlineToolbarFeature,
   lexicalEditor,
 } from '@payloadcms/richtext-lexical'
-import path from 'path'
-import { fileURLToPath } from 'url'
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const Media: CollectionConfig = {
   slug: 'media',
@@ -39,21 +34,6 @@ export const Media: CollectionConfig = {
     },
   ],
   upload: {
-    // Upload to the public/media directory in Next.js making them publicly accessible even outside of Payload
-    staticDir: path.resolve(dirname, '../../public/media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-      {
-        name: 'og',
-        width: 1200,
-        height: 630,
-        crop: 'center',
-      },
-    ],
   },
 }

--- a/src/collections/SoundMedia.ts
+++ b/src/collections/SoundMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const SoundMedia: CollectionConfig = {
   slug: 'sound-media',
@@ -43,14 +38,6 @@ export const SoundMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/sound-media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
   },
 }

--- a/src/collections/TravelMedia.ts
+++ b/src/collections/TravelMedia.ts
@@ -8,11 +8,6 @@ import {
 
 import { anyone } from '../access/anyone'
 import { authenticated } from '../access/authenticated'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
 
 export const TravelMedia: CollectionConfig = {
   slug: 'travel-media',
@@ -43,14 +38,6 @@ export const TravelMedia: CollectionConfig = {
     },
   ],
   upload: {
-    staticDir: path.resolve(dirname, '../../public/travel-media'),
-    adminThumbnail: 'thumbnail',
     focalPoint: true,
-    imageSizes: [
-      {
-        name: 'thumbnail',
-        width: 300,
-      },
-    ],
   },
 }

--- a/src/components/Media/ImageMedia/index.tsx
+++ b/src/components/Media/ImageMedia/index.tsx
@@ -25,7 +25,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
     size: sizeFromProps,
     src: publicIdFromProps,
     loading: loadingFromProps,
-    quality = 95,
+    quality = 'auto',
   } = props
 
   let width: number | undefined
@@ -54,6 +54,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
         alt={alt}
         className={cn(imgClassName)}
         fill={fill}
+        width={!fill ? width : undefined}
         height={!fill ? height : undefined}
         placeholder="blur"
         blurDataURL={placeholderBlur}
@@ -63,7 +64,6 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
         loading={loading}
         sizes={sizes}
         src={publicIdFromProps ? (publicIdFromProps as string) : publicId}
-        width={!fill ? width : undefined}
       />
     </picture>
   )

--- a/src/components/Media/types.ts
+++ b/src/components/Media/types.ts
@@ -18,5 +18,5 @@ export interface Props {
   size?: string // for NextImage only
   src?: string | StaticImageData // for static media
   videoClassName?: string
-  quality?: number
+  quality?: number | string
 }

--- a/src/features/search/fieldOverrides.ts
+++ b/src/features/search/fieldOverrides.ts
@@ -32,7 +32,7 @@ export const searchFields: Field[] = [
         name: 'image',
         label: 'Image',
         type: 'upload',
-        relationTo: 'media',
+        relationTo: 'article-media',
       },
     ],
   },

--- a/src/features/shared/components/RenderMedia.tsx
+++ b/src/features/shared/components/RenderMedia.tsx
@@ -1,10 +1,31 @@
 import { Media } from '@/components/Media'
-import type { Media as MediaType } from '@/payload-types'
+import type {
+  Media as MediaType,
+  AdMedia,
+  HomeMedia,
+  LiteratureMedia,
+  SoundMedia,
+  ArtMedia,
+  TravelMedia,
+  HealthAndWellnessMedia,
+  ArticleMedia,
+} from '@/payload-types'
 
 import React from 'react'
 
+type AnyMedia =
+  | MediaType
+  | AdMedia
+  | HomeMedia
+  | LiteratureMedia
+  | SoundMedia
+  | ArtMedia
+  | TravelMedia
+  | HealthAndWellnessMedia
+  | ArticleMedia
+
 type RenderMediaProps = {
-  media: string | MediaType
+  media: string | AnyMedia
   quality?: number | string
   size?: string
 }

--- a/src/features/shared/components/RenderMedia.tsx
+++ b/src/features/shared/components/RenderMedia.tsx
@@ -3,6 +3,20 @@ import type { Media as MediaType } from '@/payload-types'
 
 import React from 'react'
 
-export function RenderMedia({ media }: { media: string | MediaType }) {
-  return <Media resource={media} imgClassName="size-full object-cover" fill />
+type RenderMediaProps = {
+  media: string | MediaType
+  quality?: number | string
+  size?: string
+}
+
+export function RenderMedia({ media, quality, size }: RenderMediaProps) {
+  return (
+    <Media
+      resource={media}
+      quality={quality}
+      size={size}
+      imgClassName="size-full object-cover"
+      fill
+    />
+  )
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1537,16 +1537,6 @@ export interface AdMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2568,20 +2558,6 @@ export interface AdMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -390,24 +390,6 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-    og?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1012,16 +994,6 @@ export interface HomeMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1117,16 +1089,6 @@ export interface LiteratureMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1222,16 +1184,6 @@ export interface SoundMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1327,16 +1279,6 @@ export interface ArtMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1432,16 +1374,6 @@ export interface TravelMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1632,16 +1564,6 @@ export interface HealthAndWellnessMedia {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  sizes?: {
-    thumbnail?: {
-      url?: string | null;
-      width?: number | null;
-      height?: number | null;
-      mimeType?: string | null;
-      filesize?: number | null;
-      filename?: string | null;
-    };
-  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2242,30 +2164,6 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-        og?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2303,20 +2201,6 @@ export interface HomeMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2354,20 +2238,6 @@ export interface LiteratureMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2405,20 +2275,6 @@ export interface SoundMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2456,20 +2312,6 @@ export interface ArtMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2507,20 +2349,6 @@ export interface TravelMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2595,20 +2423,6 @@ export interface HealthAndWellnessMediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  sizes?:
-    | T
-    | {
-        thumbnail?:
-          | T
-          | {
-              url?: T;
-              width?: T;
-              height?: T;
-              mimeType?: T;
-              filesize?: T;
-              filename?: T;
-            };
-      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -78,6 +78,7 @@ export interface Config {
     'travel-media': TravelMedia;
     'ad-media': AdMedia;
     'health-and-wellness-media': HealthAndWellnessMedia;
+    'article-media': ArticleMedia;
     categories: Category;
     topics: Topic;
     users: User;
@@ -103,6 +104,7 @@ export interface Config {
     'travel-media': TravelMediaSelect<false> | TravelMediaSelect<true>;
     'ad-media': AdMediaSelect<false> | AdMediaSelect<true>;
     'health-and-wellness-media': HealthAndWellnessMediaSelect<false> | HealthAndWellnessMediaSelect<true>;
+    'article-media': ArticleMediaSelect<false> | ArticleMediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     topics: TopicsSelect<false> | TopicsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
@@ -248,7 +250,7 @@ export interface Page {
 export interface Article {
   id: string;
   title: string;
-  heroImage?: (string | null) | Media;
+  heroImage?: (string | null) | ArticleMedia;
   layout?: (PostingsSection | ContentSection | ResourceSection)[] | null;
   relatedArticles?: (string | Article)[] | null;
   categories?: (string | Category)[] | null;
@@ -278,7 +280,7 @@ export interface Article {
     /**
      * Maximum upload file size: 12MB. Recommended file size for images is <500KB.
      */
-    image?: (string | null) | Media;
+    image?: (string | null) | ArticleMedia;
     description?: string | null;
   };
   publishedAt?: string | null;
@@ -298,9 +300,9 @@ export interface Article {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "media".
+ * via the `definition` "article-media".
  */
-export interface Media {
+export interface ArticleMedia {
   id: string;
   alt: string;
   caption?: {
@@ -399,7 +401,7 @@ export interface PostingsSection {
   title: string;
   postings?:
     | {
-        media?: (string | null) | Media;
+        media?: (string | null) | ArticleMedia;
         enableLink?: boolean | null;
         link?: {
           type?: ('reference' | 'custom') | null;
@@ -429,8 +431,8 @@ export interface PostingsSection {
 export interface ContentSection {
   title: string;
   alignment?: ('left' | 'right' | 'left & right') | null;
-  image1?: (string | null) | Media;
-  image2?: (string | null) | Media;
+  image1?: (string | null) | ArticleMedia;
+  image2?: (string | null) | ArticleMedia;
   content?: {
     root: {
       type: string;
@@ -510,6 +512,101 @@ export interface User {
       }[]
     | null;
   password?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media".
+ */
+export interface Media {
+  id: string;
+  alt: string;
+  caption?: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  /**
+   * Cloudinary Media Information
+   */
+  cloudinary?: {
+    /**
+     * Cloudinary Public ID (used for transformations)
+     */
+    public_id?: string | null;
+    /**
+     * Type of the resource (image, video, raw)
+     */
+    resource_type?: string | null;
+    /**
+     * File format
+     */
+    format?: string | null;
+    /**
+     * Secure delivery URL
+     */
+    secure_url?: string | null;
+    /**
+     * File size in bytes
+     */
+    bytes?: number | null;
+    /**
+     * Creation timestamp
+     */
+    created_at?: string | null;
+    /**
+     * Current version number
+     */
+    version?: string | null;
+    /**
+     * Unique version identifier
+     */
+    version_id?: string | null;
+    /**
+     * Width in pixels
+     */
+    width?: number | null;
+    /**
+     * Height in pixels
+     */
+    height?: number | null;
+    /**
+     * Duration in seconds (for videos)
+     */
+    duration?: number | null;
+    /**
+     * Number of pages (for PDFs)
+     */
+    pages?: number | null;
+    /**
+     * Which page of the PDF to use for thumbnails (changes will apply after saving)
+     */
+    selected_page?: number | null;
+    /**
+     * URL for the thumbnail image (automatically generated for PDFs)
+     */
+    thumbnail_url?: string | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -614,7 +711,7 @@ export interface ContentBlock {
  * via the `definition` "MediaBlock".
  */
 export interface MediaBlock {
-  media: string | Media;
+  media: string | ArticleMedia;
   id?: string | null;
   blockName?: string | null;
   blockType: 'mediaBlock';
@@ -1626,7 +1723,7 @@ export interface Search {
   meta?: {
     title?: string | null;
     description?: string | null;
-    image?: (string | null) | Media;
+    image?: (string | null) | ArticleMedia;
   };
   categories?:
     | {
@@ -1787,6 +1884,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'health-and-wellness-media';
         value: string | HealthAndWellnessMedia;
+      } | null)
+    | ({
+        relationTo: 'article-media';
+        value: string | ArticleMedia;
       } | null)
     | ({
         relationTo: 'categories';
@@ -2392,6 +2493,43 @@ export interface AdMediaSelect<T extends boolean = true> {
  * via the `definition` "health-and-wellness-media_select".
  */
 export interface HealthAndWellnessMediaSelect<T extends boolean = true> {
+  alt?: T;
+  caption?: T;
+  cloudinary?:
+    | T
+    | {
+        public_id?: T;
+        resource_type?: T;
+        format?: T;
+        secure_url?: T;
+        bytes?: T;
+        created_at?: T;
+        version?: T;
+        version_id?: T;
+        width?: T;
+        height?: T;
+        duration?: T;
+        pages?: T;
+        selected_page?: T;
+        thumbnail_url?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "article-media_select".
+ */
+export interface ArticleMediaSelect<T extends boolean = true> {
   alt?: T;
   caption?: T;
   cloudinary?:

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -35,6 +35,7 @@ import { Travel } from './Globals/Travel/config'
 import { Topics } from './collections/Topics'
 import { AdMedia } from './collections/AdMedia'
 import { Signin } from './Globals/Signin/config'
+import { ArticleMedia } from './collections/ArticleMedia'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -104,6 +105,7 @@ export default buildConfig({
     TravelMedia,
     AdMedia,
     HealthAndWellnessMedia,
+    ArticleMedia,
     Categories,
     Topics,
     Users,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -99,6 +99,7 @@ export const plugins: Plugin[] = [
       'health-and-wellness-media': true,
       'travel-media': true,
       'ad-media': true,
+      'article-media': true,
     },
     folder: 'manza-search-media',
   }),

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -3,17 +3,12 @@ import type { Metadata } from 'next'
 import type { Media, Page, Post, Config } from '../payload-types'
 
 import { mergeOpenGraph } from './mergeOpenGraph'
-import { getServerSideURL } from './getURL'
 
 const getImageURL = (image?: Media | Config['db']['defaultIDType'] | null) => {
-  const serverUrl = getServerSideURL()
-
-  let url = serverUrl + '/manza-search-OG.webp'
+  let url = ''
 
   if (image && typeof image === 'object' && 'url' in image) {
-    const ogUrl = image.sizes?.og?.url
-
-    url = ogUrl ? serverUrl + ogUrl : serverUrl + image.url
+    url = image.cloudinary?.secure_url ?? ''
   }
 
   return url


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an Article Media library with alt text, captions, and focal-point cropping.
  - PDF uploads now capture page counts and generate thumbnails for previews.

- Refactor
  - Unified article images to use the new Article Media across the site.
  - Media rendering now accepts quality (number|string) and size props; image defaults updated (ad images default to best/responsive, general images default to auto).
  - Removed admin thumbnails, static folders, and preset image sizes from media collections.

- Chores
  - Cloudinary uploads can reuse/overwrite existing assets and optionally include timestamps.

- Bug Fixes
  - Open Graph images now use cloudinary-hosted URLs; missing cloudinary URLs are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->