### PR TITLE
feat: Article image page

### DIFF
--- a/src/app/(frontend)/articles/[slug]/images/page.client.tsx
+++ b/src/app/(frontend)/articles/[slug]/images/page.client.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { useHeaderTheme } from '@/providers/HeaderTheme'
+import React, { useEffect } from 'react'
+
+const PageClient: React.FC = () => {
+  /* Force the header to be light mode */
+  const { setHeaderTheme } = useHeaderTheme()
+
+  useEffect(() => {
+    setHeaderTheme('light')
+  }, [setHeaderTheme])
+  return <React.Fragment />
+}
+
+export default PageClient

--- a/src/app/(frontend)/articles/[slug]/images/page.tsx
+++ b/src/app/(frontend)/articles/[slug]/images/page.tsx
@@ -25,7 +25,7 @@ export default async function ArticleImages({ params }: Args) {
   return (
     <div className="min-h-screen pb-16">
       <PageClient />
-      <RelatedImages images={relatedImages || {}} />
+      <RelatedImages images={relatedImages || []} />
       <div className="h-full bg-black">
         <div className="h-full">
           {(!internalImages || internalImages.length === 0) &&

--- a/src/app/(frontend)/articles/[slug]/images/page.tsx
+++ b/src/app/(frontend)/articles/[slug]/images/page.tsx
@@ -28,8 +28,7 @@ export default async function ArticleImages({ params }: Args) {
       <RelatedImages images={relatedImages || []} />
       <div className="h-full bg-black">
         <div className="h-full">
-          {(!internalImages || internalImages.length === 0) &&
-          (!externalImages || externalImages.length === 0) ? (
+          {internalImages.length === 0 && externalImages.length === 0 ? (
             <div className="mt-12 bg-white text-center">No Images for this article yet</div>
           ) : (
             <ArticleImageGallery internalImages={internalImages} externalImages={externalImages} />
@@ -60,10 +59,10 @@ const queryArticleImagesBySlug = cache(async ({ slug }: { slug: string }) => {
     },
   })
 
-  const articles = result.docs?.[0] || null
+  const article = result.docs?.[0] || null
 
-  const images = articles?.images
-  const relatedImages = articles?.relatedImages
+  const images = article?.images
+  const relatedImages = article?.relatedImages
 
   return { images, relatedImages }
 })

--- a/src/app/(frontend)/articles/[slug]/images/page.tsx
+++ b/src/app/(frontend)/articles/[slug]/images/page.tsx
@@ -1,0 +1,91 @@
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import PageClient from './page.client'
+import { draftMode } from 'next/headers'
+import React, { cache } from 'react'
+import { RelatedImages } from '@/features/articles/components/ArticleImages/RelatedImages'
+import { ArticleImageGallery } from '@/features/articles/components/ArticleImages/ArticleImageGallery'
+import { BottomMenu } from '@/features/shared/components/BottomMenu'
+
+type Args = {
+  params: Promise<{
+    slug?: string
+  }>
+}
+
+export default async function ArticleImages({ params }: Args) {
+  const { slug = '' } = await params
+  const imagesData = await queryArticleImagesBySlug({ slug })
+
+  const { images, relatedImages } = imagesData
+
+  const internalImages = images?.filter((img) => img.imageType === 'manza-database') || []
+  const externalImages = images?.filter((img) => img.imageType === 'outside-link') || []
+
+  return (
+    <div className="min-h-screen pb-16">
+      <PageClient />
+      <RelatedImages images={relatedImages || {}} />
+      <div className="h-full bg-black">
+        <div className="h-full">
+          {(!internalImages || internalImages.length === 0) &&
+          (!externalImages || externalImages.length === 0) ? (
+            <div className="mt-12 bg-white text-center">No Images for this article yet</div>
+          ) : (
+            <ArticleImageGallery internalImages={internalImages} externalImages={externalImages} />
+          )}
+        </div>
+      </div>
+
+      <BottomMenu />
+    </div>
+  )
+}
+
+const queryArticleImagesBySlug = cache(async ({ slug }: { slug: string }) => {
+  const { isEnabled: draft } = await draftMode()
+
+  const payload = await getPayload({ config: configPromise })
+
+  const result = await payload.find({
+    collection: 'articles',
+    draft,
+    limit: 1,
+    overrideAccess: draft,
+    pagination: false,
+    where: {
+      slug: {
+        equals: slug,
+      },
+    },
+  })
+
+  const articles = result.docs?.[0] || null
+
+  const images = articles?.images
+  const relatedImages = articles?.relatedImages
+
+  return { images, relatedImages }
+})
+
+export async function generateMetadata({ params: paramsPromise }: Args) {
+  const { slug = '' } = await paramsPromise
+
+  const payload = await getPayload({ config: configPromise })
+  const result = await payload.find({
+    collection: 'articles',
+    limit: 1,
+    pagination: false,
+    where: {
+      slug: {
+        equals: slug,
+      },
+    },
+  })
+
+  const title = result.docs?.[0]?.title || null
+
+  return {
+    title: `${title} - Images | Manza Search`,
+  }
+}

--- a/src/app/(frontend)/articles/[slug]/images/page.tsx
+++ b/src/app/(frontend)/articles/[slug]/images/page.tsx
@@ -83,9 +83,7 @@ export async function generateMetadata({ params: paramsPromise }: Args) {
     },
   })
 
-  const title = result.docs?.[0]?.title || null
-
-  return {
-    title: `${title} - Images | Manza Search`,
-  }
+  const title = result.docs?.[0]?.title
+  const pageTitle = title ? `${title} - Images | Manza Search` : 'Article Images | Manza Search'
+  return { title: pageTitle }
 }

--- a/src/app/(frontend)/articles/[slug]/page.tsx
+++ b/src/app/(frontend)/articles/[slug]/page.tsx
@@ -70,15 +70,19 @@ export default async function Article({ params: paramsPromise }: Args) {
       <RelatedArticles articles={relatedArticles} />
 
       <div className="flex">
-        <ArticleLeftMenuContainer article={article} />
+        <ArticleLeftMenuContainer url={url} article={article} />
 
         <div className="flex w-full min-w-0 flex-col">
           <ReadModeProvider>
             <TextSizeProvider>
-              <ArticleTopMenuContainer article={article} className="hidden sm:block lg:ml-auto" />
+              <ArticleTopMenuContainer
+                url={url}
+                article={article}
+                className="hidden sm:block lg:ml-auto"
+              />
               {/* Hero & Content */}
               <ArticleHero article={article} />
-              <ArticleTopMenuContainer article={article} className="sm:hidden" />
+              <ArticleTopMenuContainer url={url} article={article} className="sm:hidden" />
               <ArticleAdsContainer ads={ads} />
               <RenderArticleBlocks blocks={blocks ?? []} />
             </TextSizeProvider>

--- a/src/app/api/article-images/[slug]/route.ts
+++ b/src/app/api/article-images/[slug]/route.ts
@@ -1,0 +1,55 @@
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { draftMode } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { ImageSourceKey } from '@/features/articles/components/ArticleImages/types'
+
+function isImageType(value: string | null): value is ImageSourceKey {
+  return value === 'outside-images' || value === 'internal-images'
+}
+
+export async function GET(req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug = '' } = await params
+
+  const { searchParams } = new URL(req.url)
+  const page = Number(searchParams.get('page') || 1)
+  const limit = Number(searchParams.get('limit') || 30)
+
+  const paramImagesType = searchParams.get('imagesType')
+  const imagesType: ImageSourceKey = isImageType(paramImagesType)
+    ? paramImagesType
+    : 'outside-images'
+
+  const { isEnabled: draft } = await draftMode()
+  const payload = await getPayload({ config: configPromise })
+
+  const result = await payload.find({
+    collection: 'articles',
+    draft,
+    limit: 1,
+    overrideAccess: draft,
+    pagination: false,
+    where: {
+      slug: { equals: slug },
+    },
+  })
+
+  const article = result.docs?.[0] || null
+  const allImages = article?.[imagesType] || []
+
+  const totalDocs = allImages.length
+  const totalPages = Math.ceil(totalDocs / limit)
+
+  const start = (page - 1) * limit
+  const end = start + limit
+
+  const docs = allImages.slice(start, end)
+
+  return NextResponse.json({
+    docs,
+    page,
+    limit,
+    totalDocs,
+    totalPages,
+  })
+}

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -77,6 +77,66 @@ export const Articles: CollectionConfig<'articles'> = {
           label: 'Hero',
         },
         {
+          label: 'Images',
+          fields: [
+            {
+              name: 'images',
+              type: 'array',
+              fields: [
+                {
+                  name: 'image',
+                  type: 'upload',
+                  relationTo: 'article-media',
+                },
+                {
+                  name: 'enableLink',
+                  type: 'checkbox',
+                },
+                link({
+                  overrides: {
+                    admin: {
+                      condition: (_, { enableLink }) => Boolean(enableLink),
+                    },
+                  },
+                  appearances: false,
+                  disableLabel: true,
+                }),
+                {
+                  name: 'imageType',
+                  type: 'radio',
+                  options: [
+                    {
+                      label: 'Manza Database',
+                      value: 'manza-database',
+                    },
+                    {
+                      label: 'Outside Link',
+                      value: 'outside-link',
+                    },
+                  ],
+                  defaultValue: 'manza-database',
+                },
+              ],
+            },
+            {
+              name: 'relatedImages',
+              type: 'relationship',
+              admin: {
+                position: 'sidebar',
+              },
+              filterOptions: ({ id }) => {
+                return {
+                  id: {
+                    not_in: [id],
+                  },
+                }
+              },
+              hasMany: true,
+              relationTo: 'articles',
+            },
+          ],
+        },
+        {
           fields: [
             {
               name: 'layout',

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -80,45 +80,6 @@ export const Articles: CollectionConfig<'articles'> = {
           label: 'Images',
           fields: [
             {
-              name: 'images',
-              type: 'array',
-              fields: [
-                {
-                  name: 'image',
-                  type: 'upload',
-                  relationTo: 'article-media',
-                },
-                {
-                  name: 'enableLink',
-                  type: 'checkbox',
-                },
-                link({
-                  overrides: {
-                    admin: {
-                      condition: (_, { enableLink }) => Boolean(enableLink),
-                    },
-                  },
-                  appearances: false,
-                  disableLabel: true,
-                }),
-                {
-                  name: 'imageType',
-                  type: 'radio',
-                  options: [
-                    {
-                      label: 'Manza Database',
-                      value: 'manza-database',
-                    },
-                    {
-                      label: 'Outside Link',
-                      value: 'outside-link',
-                    },
-                  ],
-                  defaultValue: 'manza-database',
-                },
-              ],
-            },
-            {
               name: 'relatedImages',
               type: 'relationship',
               admin: {
@@ -133,6 +94,32 @@ export const Articles: CollectionConfig<'articles'> = {
               },
               hasMany: true,
               relationTo: 'articles',
+            },
+            {
+              name: 'internal-images',
+              type: 'array',
+              fields: [
+                {
+                  name: 'image',
+                  type: 'upload',
+                  relationTo: 'article-media',
+                },
+              ],
+            },
+            {
+              name: 'outside-images',
+              type: 'array',
+              fields: [
+                {
+                  name: 'image',
+                  type: 'upload',
+                  relationTo: 'article-media',
+                },
+                link({
+                  appearances: false,
+                  disableLabel: true,
+                }),
+              ],
             },
           ],
         },

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -98,6 +98,7 @@ export const Articles: CollectionConfig<'articles'> = {
             {
               name: 'internal-images',
               type: 'array',
+              minRows: 1,
               fields: [
                 {
                   name: 'image',
@@ -109,6 +110,7 @@ export const Articles: CollectionConfig<'articles'> = {
             {
               name: 'outside-images',
               type: 'array',
+              minRows: 1,
               fields: [
                 {
                   name: 'image',

--- a/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
+++ b/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { Tabs, TabsContent } from '@/components/ui/tabs'
+import {
+  ImageGalleryTabsList,
+  ImageGalleryTabsTrigger,
+} from '@/features/articles/components/ArticleImages/ImageGalleryTabs'
+import { type ArticleImage, ImageGallery } from './ImageGallery'
+import { useState } from 'react'
+
+type ArticleImageGalleryProps = {
+  externalImages: ArticleImage
+  internalImages: ArticleImage
+}
+
+export function ArticleImageGallery({ externalImages, internalImages }: ArticleImageGalleryProps) {
+  const [activeTab, setActiveTab] = useState('outside-link')
+
+  const tabTitles: Record<string, string> = {
+    'outside-link': 'On Links',
+    'manza-database': 'On Manza Database',
+  }
+
+  return (
+    <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <div className="ml-0 flex flex-col items-center gap-0 sm:ml-12 sm:flex-row sm:gap-4">
+        <div className="w-[200px] text-center font-serif text-2xl text-white sm:text-right">
+          {tabTitles[activeTab]}
+        </div>
+        <ImageGalleryTabsList className="gap-2">
+          <ImageGalleryTabsTrigger value="outside-link">Links</ImageGalleryTabsTrigger>
+          <ImageGalleryTabsTrigger value="manza-database">MDB</ImageGalleryTabsTrigger>
+        </ImageGalleryTabsList>
+      </div>
+
+      <TabsContent value="outside-link" className="mt-0">
+        <ImageGallery tabTitle="Links" images={externalImages} />
+      </TabsContent>
+
+      <TabsContent value="manza-database" className="mt-0">
+        <ImageGallery tabTitle="Manza Database" images={internalImages} />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
+++ b/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
@@ -11,33 +11,66 @@ import { ArticleImageGalleryProps } from './types'
 
 type TabValue = 'outside-link' | 'manza-database'
 
-export function ArticleImageGallery({ externalImages, internalImages }: ArticleImageGalleryProps) {
+export function ArticleImageGallery({
+  externalImages,
+  internalImages,
+  hasOutsideImagesToLoad,
+  hasInternalImagesToLoad,
+  slug,
+  imageLimit,
+}: ArticleImageGalleryProps) {
   const [activeTab, setActiveTab] = useState<TabValue>('outside-link')
 
-  const tabTitles: Record<TabValue, string> = {
-    'outside-link': 'On Links',
-    'manza-database': 'On Manza Database',
-  }
+  const tabsConfig: {
+    value: TabValue
+    title: string
+    images: typeof externalImages
+    hasImagesToLoad: boolean
+    imagesType: 'outside-images' | 'internal-images'
+  }[] = [
+    {
+      value: 'outside-link',
+      title: 'On Links',
+      images: externalImages,
+      hasImagesToLoad: hasOutsideImagesToLoad,
+      imagesType: 'outside-images',
+    },
+    {
+      value: 'manza-database',
+      title: 'On Manza Database',
+      images: internalImages,
+      hasImagesToLoad: hasInternalImagesToLoad,
+      imagesType: 'internal-images',
+    },
+  ]
 
   return (
     <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabValue)}>
       <div className="ml-0 flex flex-col items-center gap-0 sm:ml-12 sm:flex-row sm:gap-4">
         <div className="w-[200px] text-center font-serif text-2xl text-white sm:text-right">
-          {tabTitles[activeTab]}
+          {tabsConfig.find((tab) => tab.value === activeTab)?.title}
         </div>
         <ImageGalleryTabsList className="gap-2">
-          <ImageGalleryTabsTrigger value="outside-link">Links</ImageGalleryTabsTrigger>
-          <ImageGalleryTabsTrigger value="manza-database">MDB</ImageGalleryTabsTrigger>
+          {tabsConfig.map((tab) => (
+            <ImageGalleryTabsTrigger key={tab.value} value={tab.value}>
+              {tab.value === 'outside-link' ? 'Links' : 'MDB'}
+            </ImageGalleryTabsTrigger>
+          ))}
         </ImageGalleryTabsList>
       </div>
 
-      <TabsContent value="outside-link" className="mt-0">
-        <ImageGallery tabTitle="Links" images={externalImages} />
-      </TabsContent>
-
-      <TabsContent value="manza-database" className="mt-0">
-        <ImageGallery tabTitle="Manza Database" images={internalImages} />
-      </TabsContent>
+      {tabsConfig.map((tab) => (
+        <TabsContent key={tab.value} value={tab.value} className="mt-0">
+          <ImageGallery
+            tabTitle={tab.title}
+            images={tab.images}
+            slug={slug}
+            imagesType={tab.imagesType}
+            hasImagesToLoad={tab.hasImagesToLoad}
+            imageLimit={imageLimit}
+          />
+        </TabsContent>
+      ))}
     </Tabs>
   )
 }

--- a/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
+++ b/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
@@ -5,13 +5,9 @@ import {
   ImageGalleryTabsList,
   ImageGalleryTabsTrigger,
 } from '@/features/articles/components/ArticleImages/ImageGalleryTabs'
-import { type ArticleImage, ImageGallery } from './ImageGallery'
+import { ImageGallery } from './ImageGallery'
 import { useState } from 'react'
-
-type ArticleImageGalleryProps = {
-  externalImages: ArticleImage
-  internalImages: ArticleImage
-}
+import { ArticleImageGalleryProps } from './types'
 
 export function ArticleImageGallery({ externalImages, internalImages }: ArticleImageGalleryProps) {
   const [activeTab, setActiveTab] = useState('outside-link')

--- a/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
+++ b/src/features/articles/components/ArticleImages/ArticleImageGallery.tsx
@@ -9,16 +9,18 @@ import { ImageGallery } from './ImageGallery'
 import { useState } from 'react'
 import { ArticleImageGalleryProps } from './types'
 
-export function ArticleImageGallery({ externalImages, internalImages }: ArticleImageGalleryProps) {
-  const [activeTab, setActiveTab] = useState('outside-link')
+type TabValue = 'outside-link' | 'manza-database'
 
-  const tabTitles: Record<string, string> = {
+export function ArticleImageGallery({ externalImages, internalImages }: ArticleImageGalleryProps) {
+  const [activeTab, setActiveTab] = useState<TabValue>('outside-link')
+
+  const tabTitles: Record<TabValue, string> = {
     'outside-link': 'On Links',
     'manza-database': 'On Manza Database',
   }
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab}>
+    <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabValue)}>
       <div className="ml-0 flex flex-col items-center gap-0 sm:ml-12 sm:flex-row sm:gap-4">
         <div className="w-[200px] text-center font-serif text-2xl text-white sm:text-right">
           {tabTitles[activeTab]}

--- a/src/features/articles/components/ArticleImages/GalleryImage.tsx
+++ b/src/features/articles/components/ArticleImages/GalleryImage.tsx
@@ -1,0 +1,40 @@
+import { CMSLink } from '@/components/Link'
+import { RenderMedia } from '@/features/shared/components/RenderMedia'
+import { ImagePlaceholder } from '@/features/shared/components/ImagePlaceholder'
+import { ArticleMediaOnly, GalleryImageProps } from './types'
+import { ImageExtraContentButton } from './ImageExtraContentButton'
+
+export function GalleryImage({
+  link,
+  enableLink,
+  image,
+  imageWidth,
+  hasValidLink,
+}: GalleryImageProps) {
+  return (
+    <div
+      className="group relative overflow-hidden border-2 border-black shadow-[10px_10px_10px_black] hover:border-secondary-blue"
+      style={{ width: `${imageWidth}px`, flexShrink: 0 }}
+    >
+      {hasValidLink && enableLink ? (
+        <CMSLink {...link}>
+          {image ? <RenderGalleryImage image={image} /> : <ImagePlaceholder />}
+        </CMSLink>
+      ) : image ? (
+        <RenderGalleryImage image={image} />
+      ) : (
+        <ImagePlaceholder />
+      )}
+
+      {image && <ImageExtraContentButton />}
+    </div>
+  )
+}
+
+type RenderGalleryImageProps = {
+  image: ArticleMediaOnly
+}
+
+function RenderGalleryImage({ image }: RenderGalleryImageProps) {
+  return <RenderMedia media={image} className="h-full w-full object-cover" />
+}

--- a/src/features/articles/components/ArticleImages/GalleryImage.tsx
+++ b/src/features/articles/components/ArticleImages/GalleryImage.tsx
@@ -1,22 +1,16 @@
 import { CMSLink } from '@/components/Link'
 import { RenderMedia } from '@/features/shared/components/RenderMedia'
 import { ImagePlaceholder } from '@/features/shared/components/ImagePlaceholder'
-import { ArticleMediaOnly, GalleryImageProps } from './types'
+import { GalleryImageProps, RenderGalleryImageProps } from './types'
 import { ImageExtraContentButton } from './ImageExtraContentButton'
 
-export function GalleryImage({
-  link,
-  enableLink,
-  image,
-  imageWidth,
-  hasValidLink,
-}: GalleryImageProps) {
+export function GalleryImage({ link, image, imageWidth, hasValidLink }: GalleryImageProps) {
   return (
     <div
       className="group relative overflow-hidden border-2 border-black shadow-[10px_10px_10px_black] hover:border-secondary-blue"
       style={{ width: `${imageWidth}px`, flexShrink: 0 }}
     >
-      {hasValidLink && enableLink ? (
+      {hasValidLink ? (
         <CMSLink {...link}>
           {image ? <RenderGalleryImage image={image} /> : <ImagePlaceholder />}
         </CMSLink>
@@ -29,10 +23,6 @@ export function GalleryImage({
       {image && <ImageExtraContentButton />}
     </div>
   )
-}
-
-type RenderGalleryImageProps = {
-  image: ArticleMediaOnly
 }
 
 function RenderGalleryImage({ image }: RenderGalleryImageProps) {

--- a/src/features/articles/components/ArticleImages/ImageExtraContentButton.tsx
+++ b/src/features/articles/components/ArticleImages/ImageExtraContentButton.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
+export function ImageExtraContentButton() {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button className="absolute bottom-2 right-2 h-fit rounded-full bg-red-600 px-2.5 py-1">
+          e
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="flex w-fit flex-col items-center border-2 border-black">
+        <div className="font-serif text-lg font-bold text-secondary-blue">Extra Content</div>
+        <ul className="flex flex-col items-center">
+          <li>
+            <Button variant="ghost" className="font-serif font-bold">
+              pin
+            </Button>
+          </li>
+          <li>
+            <Button variant="ghost" className="font-serif font-bold">
+              save
+            </Button>
+          </li>
+          <li>
+            <Button variant="ghost" className="font-serif font-bold">
+              download
+            </Button>
+          </li>
+          <li>
+            <Button variant="ghost" className="font-serif font-bold">
+              share
+            </Button>
+          </li>
+        </ul>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/features/articles/components/ArticleImages/ImageGallery.tsx
+++ b/src/features/articles/components/ArticleImages/ImageGallery.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import { isValidLink } from '@/utilities/isValidLink'
-import { CMSLink } from '@/components/Link'
-import { RenderMedia } from '@/features/shared/components/RenderMedia'
-import { ImagePlaceholder } from '@/features/shared/components/ImagePlaceholder'
 import { useEffect, useRef, useState } from 'react'
 import { ArticleImageItem, ArticleMediaOnly, ImageGalleryProps } from './types'
+import { GalleryImage } from './GalleryImage'
 
 const GAP = 16 // px gap between images
 
@@ -91,25 +89,14 @@ export function ImageGallery({ images, tabTitle }: ImageGalleryProps) {
                 const hasValidLink = isValidLink(link)
 
                 return (
-                  <div
+                  <GalleryImage
                     key={id}
-                    className="group relative overflow-hidden border-2 border-black shadow-[10px_10px_10px_black] hover:border-secondary-blue"
-                    style={{ width: `${imageWidth}px`, flexShrink: 0 }}
-                  >
-                    {hasValidLink && enableLink ? (
-                      <CMSLink {...link}>
-                        {image ? (
-                          <RenderMedia media={image} className="h-full w-full object-cover" />
-                        ) : (
-                          <ImagePlaceholder />
-                        )}
-                      </CMSLink>
-                    ) : image ? (
-                      <RenderMedia media={image} className="h-full w-full object-cover" />
-                    ) : (
-                      <ImagePlaceholder />
-                    )}
-                  </div>
+                    link={link}
+                    enableLink={enableLink}
+                    image={image}
+                    imageWidth={imageWidth}
+                    hasValidLink={hasValidLink}
+                  />
                 )
               })}
             </div>

--- a/src/features/articles/components/ArticleImages/ImageGallery.tsx
+++ b/src/features/articles/components/ArticleImages/ImageGallery.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { isValidLink } from '@/utilities/isValidLink'
+import { CMSLink } from '@/components/Link'
+import { RenderMedia } from '@/features/shared/components/RenderMedia'
+import { ImagePlaceholder } from '@/features/shared/components/ImagePlaceholder'
+import { useEffect, useRef, useState } from 'react'
+import { ArticleImageItem, ArticleMediaOnly, ImageGalleryProps } from './types'
+
+const GAP = 16 // px gap between images
+
+const calculateJustifiedRows = (
+  images: ArticleImageItem[],
+  containerWidth: number,
+  targetHeight = 200,
+) => {
+  const rows: ArticleImageItem[][] = []
+  let currentRow: ArticleImageItem[] = []
+  let currentRowWidth = 0
+
+  for (const item of images ?? []) {
+    const image = typeof item.image !== 'string' && item.image ? item.image : undefined
+    const aspectRatio = (image?.cloudinary?.width || 0) / (image?.cloudinary?.height || 1)
+    const scaledWidth = targetHeight * aspectRatio
+
+    if (currentRowWidth + (currentRow.length ? GAP : 0) + scaledWidth <= containerWidth) {
+      currentRow.push(item)
+      currentRowWidth += (currentRow.length ? GAP : 0) + scaledWidth
+    } else {
+      if (currentRow.length) rows.push([...currentRow])
+      currentRow = [item]
+      currentRowWidth = scaledWidth
+    }
+  }
+
+  if (currentRow.length) rows.push(currentRow)
+  return rows
+}
+
+export function ImageGallery({ images, tabTitle }: ImageGalleryProps) {
+  const [containerWidth, setContainerWidth] = useState(1200)
+  const [justifiedRows, setJustifiedRows] = useState<ArticleImageItem[][]>([])
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Calculate rows whenever images or container width change
+  useEffect(() => {
+    setJustifiedRows(calculateJustifiedRows(images ?? [], containerWidth, 200))
+  }, [images, containerWidth])
+
+  // Resize observer to update container width
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width)
+      }
+    })
+
+    resizeObserver.observe(container)
+    return () => resizeObserver.disconnect()
+  }, [])
+
+  if (!images || images.length === 0) {
+    return <div className="bg-white pt-12 text-center">{`No Images for ${tabTitle} yet`}</div>
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center bg-white p-4">
+      <div ref={containerRef} className="flex w-full flex-col gap-4">
+        {justifiedRows.map((row, rowIndex) => {
+          // Calculate row height based on total aspect ratios
+          const totalAspectRatio = row.reduce((sum, item) => {
+            const media = typeof item.image !== 'string' && item.image ? item.image : undefined
+            return sum + (media?.cloudinary?.width ?? 0) / (media?.cloudinary?.height ?? 1)
+          }, 0)
+
+          const rowHeight = Math.max(
+            150,
+            Math.min(250, (containerWidth - (row.length - 1) * GAP) / totalAspectRatio),
+          )
+
+          return (
+            <div key={rowIndex} className="flex gap-4" style={{ height: `${rowHeight}px` }}>
+              {row.map(({ id, link, enableLink, image: imageItem }) => {
+                const image: ArticleMediaOnly | undefined =
+                  typeof imageItem !== 'string' && imageItem ? imageItem : undefined
+                const imageWidth =
+                  rowHeight * ((image?.cloudinary?.width ?? 0) / (image?.cloudinary?.height ?? 1))
+                const hasValidLink = isValidLink(link)
+
+                return (
+                  <div
+                    key={id}
+                    className="group relative overflow-hidden border-2 border-black shadow-[10px_10px_10px_black] hover:border-secondary-blue"
+                    style={{ width: `${imageWidth}px`, flexShrink: 0 }}
+                  >
+                    {hasValidLink && enableLink ? (
+                      <CMSLink {...link}>
+                        {image ? (
+                          <RenderMedia media={image} className="h-full w-full object-cover" />
+                        ) : (
+                          <ImagePlaceholder />
+                        )}
+                      </CMSLink>
+                    ) : image ? (
+                      <RenderMedia media={image} className="h-full w-full object-cover" />
+                    ) : (
+                      <ImagePlaceholder />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/features/articles/components/ArticleImages/ImageGalleryTabs.tsx
+++ b/src/features/articles/components/ArticleImages/ImageGalleryTabs.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { cn } from '@/utilities/ui'
+
+const ImageGalleryTabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn('inline-flex h-10 items-center justify-center p-1 text-muted', className)}
+    {...props}
+  />
+))
+ImageGalleryTabsList.displayName = TabsPrimitive.List.displayName
+
+const ImageGalleryTabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-lg px-3 py-[4px] text-sm font-medium ring-offset-background transition-all hover:text-secondary-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+))
+ImageGalleryTabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+export { ImageGalleryTabsList, ImageGalleryTabsTrigger }

--- a/src/features/articles/components/ArticleImages/RelatedImages.tsx
+++ b/src/features/articles/components/ArticleImages/RelatedImages.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import React from 'react'
+import { RelatedImagesProps } from './types'
+
+export function RelatedImages({ images }: RelatedImagesProps) {
+  const hasImages = images && Array.isArray(images) && images.length > 0
+
+  return (
+    <div className="bg-black">
+      <div className="container flex w-full gap-4 overflow-x-auto py-1">
+        {hasImages &&
+          images?.map((imageItem) => {
+            if (typeof imageItem === 'object' && imageItem !== null) {
+              const { id, title, slug } = imageItem
+
+              return (
+                <Link key={id} href={`/articles/${slug}/images`}>
+                  <div className="flex justify-center whitespace-nowrap rounded-[8px] bg-white px-3 py-[2px] font-medium hover:text-secondary-blue">
+                    {title}
+                  </div>
+                </Link>
+              )
+            }
+            return null
+          })}
+      </div>
+    </div>
+  )
+}

--- a/src/features/articles/components/ArticleImages/types.ts
+++ b/src/features/articles/components/ArticleImages/types.ts
@@ -1,14 +1,25 @@
 import { Article, ArticleMedia } from '@/payload-types'
 
-export type ArticleImage = Article['images']
+export type ImageSourceKey = 'outside-images' | 'internal-images'
 
-export type ArticleImageItem = NonNullable<ArticleImage>[number]
+export type ExternalImages = Article['outside-images']
+export type InternalImages = Article['internal-images']
 
-export type ArticleMediaOnly = Extract<ArticleImageItem['image'], ArticleMedia>
+export type GalleryImages = ExternalImages | InternalImages
+
+export type GalleryImageItem = NonNullable<GalleryImages>[number]
+
+export type GalleryMedia = GalleryImageItem['image'] & ArticleMedia
+
+export type GalleryImageWithLink = Extract<GalleryImageItem, { link?: unknown }>
 
 export type ImageGalleryProps = {
-  images: ArticleImage
+  images: GalleryImages
   tabTitle: string
+  slug: string
+  imagesType: ImageSourceKey
+  imageLimit: number
+  hasImagesToLoad: boolean
 }
 
 export type RelatedImagesProps = {
@@ -16,12 +27,20 @@ export type RelatedImagesProps = {
 }
 
 export type ArticleImageGalleryProps = {
-  externalImages: ArticleImage
-  internalImages: ArticleImage
+  externalImages: ExternalImages
+  internalImages: InternalImages
+  hasOutsideImagesToLoad: boolean
+  hasInternalImagesToLoad: boolean
+  slug: string
+  imageLimit: number
 }
 
-export type GalleryImageProps = Pick<ArticleImageItem, 'link' | 'enableLink'> & {
-  image: ArticleMediaOnly | undefined
+export type GalleryImageProps = Pick<GalleryImageWithLink, 'link'> & {
+  image?: GalleryMedia
   imageWidth: number
   hasValidLink: boolean
+}
+
+export type RenderGalleryImageProps = {
+  image: GalleryMedia
 }

--- a/src/features/articles/components/ArticleImages/types.ts
+++ b/src/features/articles/components/ArticleImages/types.ts
@@ -19,3 +19,9 @@ export type ArticleImageGalleryProps = {
   externalImages: ArticleImage
   internalImages: ArticleImage
 }
+
+export type GalleryImageProps = Pick<ArticleImageItem, 'link' | 'enableLink'> & {
+  image: ArticleMediaOnly | undefined
+  imageWidth: number
+  hasValidLink: boolean
+}

--- a/src/features/articles/components/ArticleImages/types.ts
+++ b/src/features/articles/components/ArticleImages/types.ts
@@ -1,0 +1,21 @@
+import { Article, ArticleMedia } from '@/payload-types'
+
+export type ArticleImage = Article['images']
+
+export type ArticleImageItem = NonNullable<ArticleImage>[number]
+
+export type ArticleMediaOnly = Extract<ArticleImageItem['image'], ArticleMedia>
+
+export type ImageGalleryProps = {
+  images: ArticleImage
+  tabTitle: string
+}
+
+export type RelatedImagesProps = {
+  images: Omit<Article['relatedImages'], 'title' | 'updatedAt' | 'createdAt'>
+}
+
+export type ArticleImageGalleryProps = {
+  externalImages: ArticleImage
+  internalImages: ArticleImage
+}

--- a/src/features/articles/components/ArticleLeftMenu.tsx
+++ b/src/features/articles/components/ArticleLeftMenu.tsx
@@ -3,6 +3,7 @@ import { ArticleMenuButton } from './ArticleMenuButton'
 import { ArticlePopoverButton } from './ArticlePopoverButton'
 import scrollToTop from '@/utilities/scrollToTop'
 import { ArticleLeftMenuProps } from '../types'
+import Link from 'next/link'
 
 const MenuSeparator = () => <div className="mb-2 h-1 w-full bg-black" />
 
@@ -10,12 +11,16 @@ export function ArticleLeftMenu({
   authors,
   otherVerifiedSources,
   sectionTitles,
+  url,
 }: ArticleLeftMenuProps) {
   return (
     <>
       <div className="flex flex-col items-center gap-4">
         <ArticleMenuButton onClick={scrollToTop}>TOP</ArticleMenuButton>
-        <ArticleMenuButton>IMG</ArticleMenuButton>
+
+        <ArticleMenuButton asChild>
+          <Link href={`${url}/images`}>IMG</Link>
+        </ArticleMenuButton>
         <ArticleMenuButton>VIDS</ArticleMenuButton>
       </div>
 

--- a/src/features/articles/components/ArticleLeftMenuContainer.tsx
+++ b/src/features/articles/components/ArticleLeftMenuContainer.tsx
@@ -4,7 +4,7 @@ import getAuthorList from '@/utilities/getAuthorList'
 import getSectionTitles from '@/utilities/getSectionTitles'
 import { ArticleLeftMenuContainerProps } from '../types'
 
-export function ArticleLeftMenuContainer({ article }: ArticleLeftMenuContainerProps) {
+export function ArticleLeftMenuContainer({ article, url }: ArticleLeftMenuContainerProps) {
   const { populatedAuthors, externalAuthors, otherVerifiedSources, layout } = article
 
   const authorList = getAuthorList({ populatedAuthors, externalAuthors })
@@ -17,6 +17,7 @@ export function ArticleLeftMenuContainer({ article }: ArticleLeftMenuContainerPr
         authors={authorList}
         otherVerifiedSources={otherVerifiedSources}
         sectionTitles={sectionTitles}
+        url={url}
       />
     </div>
   )

--- a/src/features/articles/components/ArticleTopMenuContainer.tsx
+++ b/src/features/articles/components/ArticleTopMenuContainer.tsx
@@ -8,7 +8,7 @@ import getSectionTitles from '@/utilities/getSectionTitles'
 import { cn } from '@/utilities/ui'
 import { ArticleTopMenuContainerProps } from '../types'
 
-export function ArticleTopMenuContainer({ article, className }: ArticleTopMenuContainerProps) {
+export function ArticleTopMenuContainer({ article, className, url }: ArticleTopMenuContainerProps) {
   const { populatedAuthors, externalAuthors, otherVerifiedSources, layout } = article
 
   const authorList = getAuthorList({ populatedAuthors, externalAuthors })
@@ -30,6 +30,7 @@ export function ArticleTopMenuContainer({ article, className }: ArticleTopMenuCo
               sectionTitles={sectionTitles}
               otherVerifiedSources={otherVerifiedSources}
               authors={authorList}
+              url={url}
             />
           </DropdownMenu>
 

--- a/src/features/articles/types.ts
+++ b/src/features/articles/types.ts
@@ -21,10 +21,12 @@ export type ArticleArchiveProps = {
 export type ArticleLeftMenuProps = Pick<Article, 'otherVerifiedSources'> & {
   authors: string[]
   sectionTitles: sectionTitle[]
+  url?: string
 }
 
 export interface ArticleLeftMenuContainerProps {
   article: Article
+  url?: string
 }
 
 export type ArticleMenuButtonProps = ButtonProps & {
@@ -40,6 +42,7 @@ export type PopoverButtonProps = {
 export type ArticleTopMenuContainerProps = {
   article: Article
   className: string
+  url?: string
 }
 
 export type RelatedArticlesProps = {

--- a/src/features/shared/components/RenderMedia.tsx
+++ b/src/features/shared/components/RenderMedia.tsx
@@ -29,8 +29,6 @@ type RenderMediaProps = {
   quality?: number | string
   size?: string
   fill?: boolean
-  width?: number
-  height?: number
   className?: string
 }
 

--- a/src/features/shared/components/RenderMedia.tsx
+++ b/src/features/shared/components/RenderMedia.tsx
@@ -28,16 +28,20 @@ type RenderMediaProps = {
   media: string | AnyMedia
   quality?: number | string
   size?: string
+  fill?: boolean
+  width?: number
+  height?: number
+  className?: string
 }
 
-export function RenderMedia({ media, quality, size }: RenderMediaProps) {
+export function RenderMedia({ media, quality, size, fill = true, className }: RenderMediaProps) {
   return (
     <Media
       resource={media}
       quality={quality}
       size={size}
-      imgClassName="size-full object-cover"
-      fill
+      imgClassName={className ? className : 'size-full object-cover'}
+      fill={fill}
     />
   )
 }

--- a/src/hooks/useInfiniteImages.ts
+++ b/src/hooks/useInfiniteImages.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import {
+  GalleryImageItem,
+  ImageSourceKey,
+} from '@/features/articles/components/ArticleImages/types'
+import { useEffect, useState, useRef, useCallback } from 'react'
+
+export function useInfiniteImages(
+  slug: string,
+  initialImages: GalleryImageItem[],
+  imagesType: ImageSourceKey,
+  limit: number,
+  threshold: number = 200,
+) {
+  const [images, setImages] = useState(initialImages)
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const loaderRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    setImages(initialImages)
+    setPage(1)
+    setHasMore(true)
+  }, [slug, imagesType, initialImages])
+
+  const fetchMore = useCallback(async () => {
+    if (loading || !hasMore) return
+    setLoading(true)
+
+    const nextPage = page + 1
+    const res = await fetch(
+      `/api/article-images/${slug}?page=${nextPage}&imagesType=${imagesType}&limit=${limit}`,
+    )
+    const data = await res.json()
+
+    if (data.docs?.length > 0) {
+      setImages((prev) => [...prev, ...data.docs])
+      setPage(nextPage)
+      setHasMore(nextPage < data.totalPages)
+    } else {
+      setHasMore(false)
+    }
+
+    setLoading(false)
+  }, [page, slug, imagesType, limit, hasMore, loading])
+
+  useEffect(() => {
+    const node = loaderRef.current
+    if (!node) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          fetchMore()
+        }
+      },
+      {
+        rootMargin: `0px 0px ${threshold}px 0px`,
+        threshold: 0.1,
+      },
+    )
+
+    observer.observe(node)
+    return () => {
+      if (node) observer.unobserve(node)
+      observer.disconnect()
+    }
+  }, [fetchMore, threshold])
+
+  return { images, loaderRef, hasMore, loading }
+}

--- a/src/hooks/useInfiniteImages.ts
+++ b/src/hooks/useInfiniteImages.ts
@@ -28,22 +28,25 @@ export function useInfiniteImages(
   const fetchMore = useCallback(async () => {
     if (loading || !hasMore) return
     setLoading(true)
-
     const nextPage = page + 1
-    const res = await fetch(
-      `/api/article-images/${slug}?page=${nextPage}&imagesType=${imagesType}&limit=${limit}`,
-    )
-    const data = await res.json()
-
-    if (data.docs?.length > 0) {
-      setImages((prev) => [...prev, ...data.docs])
-      setPage(nextPage)
-      setHasMore(nextPage < data.totalPages)
-    } else {
-      setHasMore(false)
+    try {
+      const res = await fetch(
+        `/api/article-images/${slug}?page=${nextPage}&imagesType=${imagesType}&limit=${limit}`,
+      )
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      if (Array.isArray(data.docs) && data.docs.length > 0) {
+        setImages((prev) => [...prev, ...data.docs])
+        setPage(nextPage)
+        setHasMore(nextPage < data.totalPages)
+      } else {
+        setHasMore(false)
+      }
+    } catch (err) {
+      console.error('Failed to fetch more images:', err)
+    } finally {
+      setLoading(false)
     }
-
-    setLoading(false)
   }, [page, slug, imagesType, limit, hasMore, loading])
 
   useEffect(() => {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -253,10 +253,16 @@ export interface Article {
   id: string;
   title: string;
   heroImage?: (string | null) | ArticleMedia;
-  images?:
+  relatedImages?: (string | Article)[] | null;
+  'internal-images'?:
     | {
         image?: (string | null) | ArticleMedia;
-        enableLink?: boolean | null;
+        id?: string | null;
+      }[]
+    | null;
+  'outside-images'?:
+    | {
+        image?: (string | null) | ArticleMedia;
         link?: {
           type?: ('reference' | 'custom') | null;
           newTab?: boolean | null;
@@ -271,11 +277,9 @@ export interface Article {
               } | null);
           url?: string | null;
         };
-        imageType?: ('manza-database' | 'outside-link') | null;
         id?: string | null;
       }[]
     | null;
-  relatedImages?: (string | Article)[] | null;
   layout?: (PostingsSection | ContentSection | ResourceSection)[] | null;
   relatedArticles?: (string | Article)[] | null;
   categories?: (string | Category)[] | null;
@@ -2161,11 +2165,17 @@ export interface PostsSelect<T extends boolean = true> {
 export interface ArticlesSelect<T extends boolean = true> {
   title?: T;
   heroImage?: T;
-  images?:
+  relatedImages?: T;
+  'internal-images'?:
     | T
     | {
         image?: T;
-        enableLink?: T;
+        id?: T;
+      };
+  'outside-images'?:
+    | T
+    | {
+        image?: T;
         link?:
           | T
           | {
@@ -2174,10 +2184,8 @@ export interface ArticlesSelect<T extends boolean = true> {
               reference?: T;
               url?: T;
             };
-        imageType?: T;
         id?: T;
       };
-  relatedImages?: T;
   layout?:
     | T
     | {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -253,6 +253,29 @@ export interface Article {
   id: string;
   title: string;
   heroImage?: (string | null) | ArticleMedia;
+  images?:
+    | {
+        image?: (string | null) | ArticleMedia;
+        enableLink?: boolean | null;
+        link?: {
+          type?: ('reference' | 'custom') | null;
+          newTab?: boolean | null;
+          reference?:
+            | ({
+                relationTo: 'pages';
+                value: string | Page;
+              } | null)
+            | ({
+                relationTo: 'articles';
+                value: string | Article;
+              } | null);
+          url?: string | null;
+        };
+        imageType?: ('manza-database' | 'outside-link') | null;
+        id?: string | null;
+      }[]
+    | null;
+  relatedImages?: (string | Article)[] | null;
   layout?: (PostingsSection | ContentSection | ResourceSection)[] | null;
   relatedArticles?: (string | Article)[] | null;
   categories?: (string | Category)[] | null;
@@ -2138,6 +2161,23 @@ export interface PostsSelect<T extends boolean = true> {
 export interface ArticlesSelect<T extends boolean = true> {
   title?: T;
   heroImage?: T;
+  images?:
+    | T
+    | {
+        image?: T;
+        enableLink?: T;
+        link?:
+          | T
+          | {
+              type?: T;
+              newTab?: T;
+              reference?: T;
+              url?: T;
+            };
+        imageType?: T;
+        id?: T;
+      };
+  relatedImages?: T;
   layout?:
     | T
     | {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Article Images page: two-tab gallery (Links / Manza Database), justified responsive layout, image cards with extra-content actions, related-images scroller, and infinite-scroll loading.
  * Light header theme applied on image pages.

* **Improvements**
  * Page titles include article name for image pages.
  * Article menus add a direct Images navigation link and accept a URL prop.
  * Media renderer supports fill and custom className.

* **CMS**
  * New Images tab for Articles with related, internal, and external image groups.

* **API**
  * New paginated endpoint serving article images by slug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->